### PR TITLE
Add more MQTT connection parameters and do more logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.4
 
 LABEL maintainer="Michael Oberdorf IT-Consulting <info@oberdorf-itc.de>"
-LABEL site.local.program.version="1.0.0"
+LABEL site.local.program.version="1.1.0"
 
 ENV CONFIG_FILE=/app/etc/mqtt2elasticsearch.json \
     ELASTICSEARCH_MAPPING_FILE=/app/etc/mqtt2elasticsearch-mappings.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Container image: [DockerHub](https://hub.docker.com/repository/docker/oitc/mqtt2
 
 # Supported tags and respective `Dockerfile` links
 
-* [`latest`, `1.1.0`](https://github.com/cybcon/docker.mqtt2elasticsearch/blob/v1.0.0/Dockerfile)
+* [`latest`, `1.1.0`](https://github.com/cybcon/docker.mqtt2elasticsearch/blob/v1.1.0/Dockerfile)
 * [`1.0.0`](https://github.com/cybcon/docker.mqtt2elasticsearch/blob/v1.0.0/Dockerfile)
 
 # Summary

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Container image: [DockerHub](https://hub.docker.com/repository/docker/oitc/mqtt2
 
 # Supported tags and respective `Dockerfile` links
 
-* [`latest`, `1.0.0`](https://github.com/cybcon/docker.mqtt2elasticsearch/blob/v1.0.0/Dockerfile)
+* [`latest`, `1.1.0`](https://github.com/cybcon/docker.mqtt2elasticsearch/blob/v1.0.0/Dockerfile)
+* [`1.0.0`](https://github.com/cybcon/docker.mqtt2elasticsearch/blob/v1.0.0/Dockerfile)
 
 # Summary
 
@@ -53,26 +54,30 @@ Inside this file we need to configure the Elasticsearch and MQTT server connecti
   "password": "myPassword",
   "server": "test.mosquitto.org",
   "port": 1883,
-  "tls": false
+  "tls": false,
+  "hostname_validation": true,
+  "protocol_version": 3
   }
 }
 ```
 
 ### Field description
 
-| Field                   | Type    | Description                                                                                                      |
-|-------------------------|---------|------------------------------------------------------------------------------------------------------------------|
-| `DEBUG`                 | Boolean | Enable debug output on stdout                                                                                    |
-| `removeIndex`           | Boolean | If this flag is set to `true`, the script will remove the Elasticsearch index and exits.                         |
-| `elasticsearch`         | Object  | Contains Elasticsearch specific configuration parameters.                                                        |
-| `elasticsearch.cluster` | Array   | Contains a list of Eleasticsearch cluster node URLs.                                                             |
-| `mqtt`                  | Object  | Contains MQTT specific configuration parameters.                                                                 |
-| `mqtt.client_id`        | String  | The MQTT client identifier.                                                                                      |
-| `mqtt.user`             | String  | The username to authenticate to the MQTT server.                                                                 |
-| `mqtt.password`         | String  | The password to authenticate to the MQTT server.                                                                 |
-| `mqtt.server`           | String  | IP address or FQDN of the MQTT server.                                                                           |
-| `mqtt.port`             | String  | The TCP port number of the MQTT server.                                                                          |
-| `mqtt.tls`              | Boolean | If a TLS encrpted communication should be established or not.                                                    |
+| Field                      | Type    | Description                                                                                                      |
+|----------------------------|---------|------------------------------------------------------------------------------------------------------------------|
+| `DEBUG`                    | Boolean | Enable debug output on stdout                                                                                    |
+| `removeIndex`              | Boolean | If this flag is set to `true`, the script will remove the Elasticsearch index and exits.                         |
+| `elasticsearch`            | Object  | Contains Elasticsearch specific configuration parameters.                                                        |
+| `elasticsearch.cluster`    | Array   | Contains a list of Eleasticsearch cluster node URLs.                                                             |
+| `mqtt`                     | Object  | Contains MQTT specific configuration parameters.                                                                 |
+| `mqtt.client_id`           | String  | The MQTT client identifier.                                                                                      |
+| `mqtt.user`                | String  | The username to authenticate to the MQTT server.                                                                 |
+| `mqtt.password`            | String  | The password to authenticate to the MQTT server.                                                                 |
+| `mqtt.server`              | String  | IP address or FQDN of the MQTT server.                                                                           |
+| `mqtt.port`                | String  | The TCP port number of the MQTT server.                                                                          |
+| `mqtt.tls`                 | Boolean | If a TLS encrpted communication should be established or not.                                                    |
+| `mqtt.hostname_validation` | Boolean | Validate the hostname from the servercertificate or not.                                                         |
+| `mqtt.protocol_version`    | Integer | The MQTT protocol version. Can be 3 (for MQTTv311) or 5 (for MQTTv5).                                            |
 
 
 ##  Elasticsearch index configuration file

--- a/src/app/bin/mqtt2elasticsearch.py
+++ b/src/app/bin/mqtt2elasticsearch.py
@@ -16,7 +16,7 @@ import paho.mqtt.client as mqtt
 from datetime import datetime
 from elasticsearch import Elasticsearch
 
-VERSION='1.0.1'
+VERSION='1.1.0'
 
 CONFIG_FILE='/app/etc/mqtt2elasticsearch.json'
 if 'CONFIG_FILE' in os.environ:

--- a/src/app/bin/mqtt2elasticsearch.py
+++ b/src/app/bin/mqtt2elasticsearch.py
@@ -11,11 +11,12 @@ import os
 import sys
 import json
 import logging
+import ssl
 import paho.mqtt.client as mqtt
 from datetime import datetime
 from elasticsearch import Elasticsearch
 
-VERSION='1.0.0'
+VERSION='1.0.1'
 
 CONFIG_FILE='/app/etc/mqtt2elasticsearch.json'
 if 'CONFIG_FILE' in os.environ:
@@ -26,6 +27,7 @@ ELASTICSEARCH_MAPPING_FILE='/app/etc/mqtt2elasticsearch-mappings.json'
 if 'ELASTICSEARCH_MAPPING_FILE' in os.environ:
   ELASTICSEARCH_MAPPING_FILE=os.environ['ELASTICSEARCH_MAPPING_FILE']
 with open(ELASTICSEARCH_MAPPING_FILE) as f: topic2index = json.load(f)
+
 
 """
 ###############################################################################
@@ -191,19 +193,38 @@ if not 'mqtt' in CONFIG:
   log.error('MQTT specific configuration is missing in {}'.format(ELASTICSEARCH_MAPPING_FILE))
 if not 'tls' in CONFIG['mqtt']:
   CONFIG['mqtt']['tls']=False
+if not 'client_id' in CONFIG['mqtt']:
+  CONFIG['mqtt']['client_id']=None
+if not 'hostname_validation' in CONFIG['mqtt']:
+  CONFIG['mqtt']['hostname_validation']=True
+if not 'protocol_version' in CONFIG['mqtt']:
+  CONFIG['mqtt']['protocol_version']=3
 
 #------------------------------------------------------------------------------
 es = Elasticsearch(CONFIG['elasticsearch']['cluster'])
 
-client = mqtt.Client(client_id=CONFIG['mqtt']['client_id'], clean_session=True, userdata=None)
+log.debug('Configure MQTT client:')
+log.debug('- client_id={}'.format(CONFIG['mqtt']['client_id']))
+log.debug('- transport=tcp')
+if CONFIG['mqtt']['protocol_version'] == 5:
+  log.debug('- protocol=MQTTv5')
+  client = mqtt.Client(client_id=CONFIG['mqtt']['client_id'], userdata=None, transport='tcp', protocol=mqtt.MQTTv5)
+else:
+  log.debug('- clean_session=True')
+  log.debug('- protocol=MQTTv5')
+  client = mqtt.Client(client_id=CONFIG['mqtt']['client_id'], clean_session=True, userdata=None, transport='tcp', protocol=mqtt.MQTTv311)
 
 if 'user' in CONFIG['mqtt'] and CONFIG['mqtt']['user'] != '' and 'password' in CONFIG['mqtt'] and CONFIG['mqtt']['password'] != '':
-  log.debug('Set username and password for MQTT connection')
+  log.debug('Set username ({}) and password for MQTT connection'.format(CONFIG['mqtt']['user']))
   client.username_pw_set(CONFIG['mqtt']['user'], password=CONFIG['mqtt']['password'])
 
 if CONFIG['mqtt']['tls']:
   log.debug('MQTT connection is TLS encrypted')
-  client.tls_set()
+  client.tls_set(ca_certs=None, cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS, ciphers=None)
+  if CONFIG['mqtt']['hostname_validation']:
+    client.tls_insecure_set(False)
+  else:
+    client.tls_insecure_set(True)
 
 # initial creation of elasticsearch index
 for key, value in topic2index.items():
@@ -214,6 +235,9 @@ for key, value in topic2index.items():
 # register MQTT callback functions
 client.on_connect = on_connect
 client.on_message = on_message
+
+# connect to MQTT server
+log.debug('Connecting to MQTT server {}:{}'.format(CONFIG['mqtt']['server'], CONFIG['mqtt']['port']))
 client.connect(CONFIG['mqtt']['server'], CONFIG['mqtt']['port'], 60)
 
 # Blocking call that processes network traffic, dispatches callbacks and

--- a/src/app/etc/mqtt2elasticsearch.json
+++ b/src/app/etc/mqtt2elasticsearch.json
@@ -1,7 +1,6 @@
 {
 "DEBUG": true,
 "removeIndex": false,
-"local_timezone": "Europe/Berlin",
 "elasticsearch": {
   "cluster": [ "http://elasticsearch:9200/" ]
   },
@@ -11,6 +10,8 @@
   "password": "myPassword",
   "server": "test.mosquitto.org",
   "port": 1883,
-  "tls": false
+  "tls": false,
+  "hostname_validation": false,
+  "protocol_version": 3
   }
 }


### PR DESCRIPTION
# Summary

## New features:
- Add new parameter `hostname_validation` to be able to do also insecure TLS commuication
- Add new parameter `protocol_version` to select between MQTTv311 and MQTTv5 protocol versions
- Remove `local_timezone` parameter, because it was not used
- Add more debug logging output